### PR TITLE
Added a line to child node

### DIFF
--- a/search.py
+++ b/search.py
@@ -109,11 +109,12 @@ class Node:
 
     def child_node(self, problem, action):
         """[Figure 3.10]"""
-        next_node = problem.result(self.state, action)
-        return Node(next_node, self, action,
+        next_state = problem.result(self.state, action)
+        next_node = Node(next_node, self, action,
                     problem.path_cost(self.path_cost, self.state,
                                       action, next_node))
-
+        return next_node
+    
     def solution(self):
         """Return the sequence of actions to go from the root to this node."""
         return [node.action for node in self.path()[1:]]


### PR DESCRIPTION
`child_node` method of `Node` uses the `problem.result` which returns normally a state not a node according to its docstring in `Problem`. Naming the variable `next_node` can be confusing to users when it actually refers to a resulting state.